### PR TITLE
Update ChromePdf.php

### DIFF
--- a/src/ChromePdf.php
+++ b/src/ChromePdf.php
@@ -61,7 +61,7 @@ class ChromePdf
 
     public function generateFromFile($file)
     {
-        if ($file{0} !== '/') {
+        if ($file[0] !== '/') {
             $file = getcwd() . '/' . $file;
         }
 


### PR DESCRIPTION
Fix deprecation introduced in PHP 7.4 - Array and string offset access syntax with curly braces is deprecated